### PR TITLE
Issues when not using ActiveRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ name = NameOfPerson::PersonName.full("David Heinemeier Hansson")
 name.first # => "David"
 ```
 
+## Installation
+
+```ruby
+# Gemfile
+gem 'name_of_person'
+```
+
+If you are using this outside of Rails, make sure `ActiveRecord` and/or `ActiveModel` are manually required.
+
+```ruby
+require 'active_record'
+# and/or
+require 'active_model'
+```
+
 ## Maintenance Expectations
 
 This library is an extraction from Basecamp that's been sufficient in almost unaltered form for over 10 years. While contributions are always welcome, do not expect a lot of feature evolution beyond the basics. Feel free to fork this library if you'd like to add large upgrades like titulations or different accommodations for other languages.

--- a/lib/name_of_person.rb
+++ b/lib/name_of_person.rb
@@ -1,5 +1,6 @@
 module NameOfPerson
 end
 
+require 'name_of_person/has_person_name'
 require 'name_of_person/loaders/active_model_has_person_name'
 require 'name_of_person/loaders/active_record_has_person_name'

--- a/lib/name_of_person/loaders/active_model_has_person_name.rb
+++ b/lib/name_of_person/loaders/active_model_has_person_name.rb
@@ -1,9 +1,3 @@
-begin
-  require 'active_model'
-  require 'name_of_person/has_person_name'
-
-  require 'active_model/model'
+if defined?(ActiveModel)
   ActiveModel::Model.send :include, NameOfPerson::HasPersonName
-rescue LoadError
-  # Active Model won't be auto-configured with has_person_name
 end

--- a/lib/name_of_person/loaders/active_record_has_person_name.rb
+++ b/lib/name_of_person/loaders/active_record_has_person_name.rb
@@ -1,8 +1,3 @@
-begin
-  require 'active_record'
-  require 'name_of_person/has_person_name'
-
+if defined?(ActiveRecord)
   ActiveRecord::Base.send :include, NameOfPerson::HasPersonName
-rescue LoadError
-  # Active Record won't be auto-configured with has_person_name
 end

--- a/test/has_person_name_test.rb
+++ b/test/has_person_name_test.rb
@@ -1,7 +1,8 @@
 require 'active_support'
 require 'active_support/testing/autorun'
 
-require 'name_of_person/loaders/active_model_has_person_name'
+require 'active_model'
+require 'name_of_person'
 
 class ModelPerson
   include ActiveModel::Model


### PR DESCRIPTION
I ran across a couple of issues when not using `ActiveRecord` in a Rails app.

1. All tests fail with error:

```
ActiveRecord::ConnectionNotEstablished: No connection pool with 'primary' found.
```

2. Deploying to Heroku fails with error:

```
 URI::InvalidURIError: bad URI(is not URI?): ://user:pass@127.0.0.1/dbname
```

This PR does not automatically load `ActiveRecord` or `ActiveModel` but rather checks to see if they are defined. Therefore these errors are no longer an issue. Nothing has to be changed in a Rails app since both are typically already required. See updated README for additional info.