### PR TITLE
Allows #initials to work if the person's name is a single letter

### DIFF
--- a/lib/name_of_person/person_name.rb
+++ b/lib/name_of_person/person_name.rb
@@ -42,7 +42,7 @@ module NameOfPerson
 
     # Returns just the initials.
     def initials
-      @initials ||= remove(/(\(|\[).*(\)|\])/).scan(/([[:word:]])[[:word:]]+/i).join
+      @initials ||= remove(/(\(|\[).*(\)|\])/).scan(/([[:word:]])[[:word:]]*/i).join
     end
 
     # Returns a mentionable version of the familiar name

--- a/test/person_name_test.rb
+++ b/test/person_name_test.rb
@@ -86,6 +86,11 @@ class PersonNameTest < ActiveSupport::TestCase
     assert_equal 'CM', name.initials
   end
 
+  test "initials single letter" do
+    name = PersonName.full('C')
+    assert_equal 'C', name.initials
+  end
+
   test "from full name" do
     name = PersonName.full('Will St. Clair')
     assert_equal 'Will', name.first


### PR DESCRIPTION
Currently, if a person's name is a single letter, their initials will be blank.  If we want to assume that a single letter is an invalid name for the purposes of this lib, that works, but I noticed this and thought it might make sense to patch.