### PR TITLE
Possessive with first or last name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@ end
 # Saves a new record using { first_name: "David", last_name: "Heinemeier Hansson" }
 person = Person.create! name: "David Heinemeier Hansson"
 
-person.name.full        # => "David Heinemeier Hansson"
-person.name.first       # => "David"
-person.name.last        # => "Heinemeier Hansson"
-person.name.initials    # => "DHH"
-person.name.familiar    # => "David H."
-person.name.abbreviated # => "D. Heinemeier Hansson"
-person.name.sorted      # => "Heinemeier Hansson, David"
-person.name.mentionable # => "davidh"
-person.name.possessive  # => "David Heinemeier Hansson's"
+person.name.full                           # => "David Heinemeier Hansson"
+person.name.first                          # => "David"
+person.name.last                           # => "Heinemeier Hansson"
+person.name.initials                       # => "DHH"
+person.name.familiar                       # => "David H."
+person.name.abbreviated                    # => "D. Heinemeier Hansson"
+person.name.sorted                         # => "Heinemeier Hansson, David"
+person.name.mentionable                    # => "davidh"
+person.name.possessive                     # => "David Heinemeier Hansson's"
+person.name.possessive(first_name: false)  # => "Heinemeier Hansson's"
+person.name.possessive(last_name: false)   # => "David's"
 
 # Use directly
 name = NameOfPerson::PersonName.full("David Heinemeier Hansson")

--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ end
 # Saves a new record using { first_name: "David", last_name: "Heinemeier Hansson" }
 person = Person.create! name: "David Heinemeier Hansson"
 
-person.name.full                           # => "David Heinemeier Hansson"
-person.name.first                          # => "David"
-person.name.last                           # => "Heinemeier Hansson"
-person.name.initials                       # => "DHH"
-person.name.familiar                       # => "David H."
-person.name.abbreviated                    # => "D. Heinemeier Hansson"
-person.name.sorted                         # => "Heinemeier Hansson, David"
-person.name.mentionable                    # => "davidh"
-person.name.possessive                     # => "David Heinemeier Hansson's"
-person.name.possessive(first_name: false)  # => "Heinemeier Hansson's"
-person.name.possessive(last_name: false)   # => "David's"
+person.name.full               # => "David Heinemeier Hansson"
+person.name.first              # => "David"
+person.name.last               # => "Heinemeier Hansson"
+person.name.initials           # => "DHH"
+person.name.familiar           # => "David H."
+person.name.abbreviated        # => "D. Heinemeier Hansson"
+person.name.sorted             # => "Heinemeier Hansson, David"
+person.name.mentionable        # => "davidh"
+person.name.possessive         # => "David Heinemeier Hansson's"
+person.name.possessive(:first) # => "David's"
+person.name.possessive(:last)  # => "Heinemeier Hansson's"
 
 # Use directly
 name = NameOfPerson::PersonName.full("David Heinemeier Hansson")

--- a/lib/name_of_person/person_name.rb
+++ b/lib/name_of_person/person_name.rb
@@ -38,7 +38,7 @@ module NameOfPerson
     # Returns name with with trailing 's or ' if name ends in s.
     # Pass in :full, :first, or :last as a parameter to use the full,
     # first, or last name (defaults to :full).
-    def possessive(base=:full)
+    def possessive(base = :full)
       unless [:full, :first, :last].include?(base)
         raise ArgumentError, "Base parameter must be :full, :first, or :last"
       end

--- a/lib/name_of_person/person_name.rb
+++ b/lib/name_of_person/person_name.rb
@@ -36,8 +36,13 @@ module NameOfPerson
     end
 
     # Returns full name with with trailing 's or ' if name ends in s.
-    def possessive
-      @possessive ||= "#{self}'#{"s" unless end_with?("s")}"
+    def possessive(first_name: true, last_name: true)
+      base = []
+      base << first if first_name && first.present?
+      base << last if last_name && last.present?
+      base = base.join(' ')
+
+      "#{base}'#{"s" unless base.end_with?("s")}"
     end
 
     # Returns just the initials.

--- a/lib/name_of_person/person_name.rb
+++ b/lib/name_of_person/person_name.rb
@@ -35,14 +35,21 @@ module NameOfPerson
       @sorted ||= last.present? ? "#{last}, #{first}" : first
     end
 
-    # Returns full name with with trailing 's or ' if name ends in s.
-    def possessive(first_name: true, last_name: true)
-      base = []
-      base << first if first_name && first.present?
-      base << last if last_name && last.present?
-      base = base.join(' ')
+    # Returns name with with trailing 's or ' if name ends in s.
+    # Pass in :full, :first, or :last as a parameter to use the full,
+    # first, or last name (defaults to :full).
+    def possessive(base=:full)
+      unless [:full, :first, :last].include?(base)
+        raise ArgumentError, "Base parameter must be :full, :first, or :last"
+      end
 
-      "#{base}'#{"s" unless base.end_with?("s")}"
+      @possessive ||= Hash.new
+      @possessive[base] ||= begin
+        base_name = send(base)
+        return if base_name.blank?
+
+        "#{base_name}'#{'s' unless base_name.end_with?('s')}"
+      end
     end
 
     # Returns just the initials.

--- a/test/person_name_test.rb
+++ b/test/person_name_test.rb
@@ -52,13 +52,23 @@ class PersonNameTest < ActiveSupport::TestCase
 
   test "possessive" do
     assert_equal "#{@name.full}'s", @name.possessive
-    assert_equal "#{@name.last}'s", @name.possessive(first_name: false)
-    assert_equal "#{@name.first}'s", @name.possessive(last_name: false)
+    assert_equal "#{@name.full}'s", @name.possessive(:full)
+    assert_equal "#{@name.first}'s", @name.possessive(:first)
+    assert_equal "#{@name.last}'s", @name.possessive(:last)
+
     assert_equal "#{@first.full}'s", @first.possessive
+    assert_equal "#{@first.full}'s", @first.possessive(:full)
+    assert_equal "#{@first.full}'s", @first.possessive(:first)
+    assert_nil @first.possessive(:last)
 
     assert_equal "Foo Bars'", PersonName.new('Foo', 'Bars').possessive
-    assert_equal "Bars'", PersonName.new('Foo', 'Bars').possessive(first_name: false)
-    assert_equal "Foo's", PersonName.new('Foo', 'Bars').possessive(last_name: false)
+    assert_equal "Foo Bars'", PersonName.new('Foo', 'Bars').possessive(:full)
+    assert_equal "Foo's", PersonName.new('Foo', 'Bars').possessive(:first)
+    assert_equal "Bars'", PersonName.new('Foo', 'Bars').possessive(:last)
+
+    assert_raise ArgumentError do
+      @name.possessive(:whoops)
+    end
   end
 
   test "initials" do

--- a/test/person_name_test.rb
+++ b/test/person_name_test.rb
@@ -52,8 +52,13 @@ class PersonNameTest < ActiveSupport::TestCase
 
   test "possessive" do
     assert_equal "#{@name.full}'s", @name.possessive
+    assert_equal "#{@name.last}'s", @name.possessive(first_name: false)
+    assert_equal "#{@name.first}'s", @name.possessive(last_name: false)
     assert_equal "#{@first.full}'s", @first.possessive
+
     assert_equal "Foo Bars'", PersonName.new('Foo', 'Bars').possessive
+    assert_equal "Bars'", PersonName.new('Foo', 'Bars').possessive(first_name: false)
+    assert_equal "Foo's", PersonName.new('Foo', 'Bars').possessive(last_name: false)
   end
 
   test "initials" do


### PR DESCRIPTION
Add optional parameter to `PersonName#possessive` to use the possessive form on either the full, first, or the last name:

```ruby
person.name.possessive         # => "David Heinemeier Hansson's"
person.name.possessive(:first) # => "David's"
person.name.possessive(:last)  # => "Heinemeier Hansson's"
```

I needed to use the possessive form on a person's first name and thought this added flexibility without complexity, with some easy extensibility if users ever want to support things like "DHH's", "David H.'s", "D. Heinemeier Hansson's" etc.