### PR TITLE
Add support for reasonable name formats in the possessive method

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ person.name.abbreviated # => "D. Heinemeier Hansson"
 person.name.sorted      # => "Heinemeier Hansson, David"
 person.name.mentionable # => "davidh"
 person.name.possessive  # => "David Heinemeier Hansson's"
+person.name.possessive(:first)  # => "David's"
+person.name.possessive(:last)  # => "Hansson's"
+person.name.possessive(:initials)  # => "DHH's"
+person.name.possessive(:sorted)  # => "Heinemeier Hansson, David's"
+person.name.possessive(:abbreviated)  # => "D. Heinemeier Hansson's"
+
 
 # Use directly
 name = NameOfPerson::PersonName.full("David Heinemeier Hansson")

--- a/lib/name_of_person/person_name.rb
+++ b/lib/name_of_person/person_name.rb
@@ -36,8 +36,16 @@ module NameOfPerson
     end
 
     # Returns full name with with trailing 's or ' if name ends in s.
-    def possessive
-      @possessive ||= "#{self}'#{"s" unless end_with?("s")}"
+    def possessive(method = :full)
+      whitelist = %i[full first last abbreviated sorted initials]
+
+      unless whitelist.include?(method.to_sym)
+        raise ArgumentError, 'Please provide a valid method'
+      end
+
+      name = public_send(method)
+
+      @possessive ||= "#{name}'#{'s' unless name.downcase.end_with?('s')}"
     end
 
     # Returns just the initials.

--- a/test/person_name_test.rb
+++ b/test/person_name_test.rb
@@ -56,6 +56,32 @@ class PersonNameTest < ActiveSupport::TestCase
     assert_equal "Foo Bars'", PersonName.new('Foo', 'Bars').possessive
   end
 
+  test "possessive first" do
+    assert_equal "#{@name.first}'s", @name.possessive(:first)
+  end
+
+  test "possessive last" do
+    assert_equal "#{@name.last}'s", @name.possessive(:last)
+  end
+
+  test "possessive sorted" do
+    assert_equal "#{@name.sorted}'s", @name.possessive(:sorted)
+  end
+
+  test "possessive initials" do
+    assert_equal "#{@name.initials}'s", @name.possessive(:initials)
+  end
+  
+  test "possessive abbreviated" do
+    assert_equal "#{@name.abbreviated}'s", @name.possessive(:abbreviated)
+  end
+
+  test "possessive with invalid arguments" do
+    assert_raise ArgumentError do
+      @name.possessive(:not_allowed)
+    end
+  end
+
   test "initials" do
     name = PersonName.full('David Heinemeier Hansson')
     assert_equal 'DHH', name.initials


### PR DESCRIPTION
This extends the possessive method functionality by opening it up to using a whitelisted set of `PersonName` methods.

It allows `full`, `first`, `last`, `abbreviated`, `sorted`,  and `initials` formats.

```ruby
person.name.possessive(:first)  # => "David's"
```

- [x] Changes Tested