### PR TITLE
Fix ArgumentError (First name is required)

### DIFF
--- a/lib/name_of_person/assignable_name.rb
+++ b/lib/name_of_person/assignable_name.rb
@@ -10,7 +10,7 @@ module NameOfPerson
 
     # Returns a PersonName object created from the first_name and last_name attributes.
     def name
-      NameOfPerson::PersonName.new(first_name, last_name) if first_name
+      NameOfPerson::PersonName.new(first_name, last_name) if first_name.present?
     end
   end
 end


### PR DESCRIPTION
Fixes an argument error which occurs due to the mismatch of checking `if first_name` and `if first_name.present?`