### PR TITLE
fix the possessive call when calling twice with another method argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ require 'active_record'
 require 'active_model'
 ```
 
+## Run tests with
+
+`bundle exec rake test`
+
 ## No further development is going to happen
 
 This gem is essentially frozen, as the developers have decided to only deal with full names going forward in their applications. Feel free to fork this work, brand it under a new name, and continue development.

--- a/lib/name_of_person/person_name.rb
+++ b/lib/name_of_person/person_name.rb
@@ -35,17 +35,17 @@ module NameOfPerson
       @sorted ||= last.present? ? "#{last}, #{first}" : first
     end
 
-    # Returns full name with with trailing 's or ' if name ends in s.
+    # Returns full name with trailing 's or ' if name ends in s.
     def possessive(method = :full)
-      whitelist = %i[full first last abbreviated sorted initials]
+      allowed_method_names = %i[full first last abbreviated sorted initials]
 
-      unless whitelist.include?(method.to_sym)
+      unless allowed_method_names.include?(method.to_sym)
         raise ArgumentError, 'Please provide a valid method'
       end
 
       name = public_send(method)
 
-      @possessive ||= "#{name}'#{'s' unless name.downcase.end_with?('s')}"
+      "#{name}'#{'s' unless name.downcase.end_with?('s')}"
     end
 
     # Returns just the initials.
@@ -53,7 +53,7 @@ module NameOfPerson
       @initials ||= remove(/(\(|\[).*(\)|\])/).scan(/([[:word:]])[[:word:]]*/i).join
     end
 
-    # Returns a mentionable version of the familiar name
+    # Returns a mentionable version of the familiar name.
     def mentionable
       @mentionable ||= familiar.chop.delete(' ').downcase
     end

--- a/test/person_name_test.rb
+++ b/test/person_name_test.rb
@@ -52,6 +52,7 @@ class PersonNameTest < ActiveSupport::TestCase
 
   test "possessive" do
     assert_equal "#{@name.full}'s", @name.possessive
+    assert_equal "#{@name.initials}'s", @name.possessive(:initials)
     assert_equal "#{@first.full}'s", @first.possessive
     assert_equal "Foo Bars'", PersonName.new('Foo', 'Bars').possessive
   end
@@ -71,7 +72,7 @@ class PersonNameTest < ActiveSupport::TestCase
   test "possessive initials" do
     assert_equal "#{@name.initials}'s", @name.possessive(:initials)
   end
-  
+
   test "possessive abbreviated" do
     assert_equal "#{@name.abbreviated}'s", @name.possessive(:abbreviated)
   end


### PR DESCRIPTION
# Problem

When execute twice the method `possessive` of PersonName with another method argument, the memoized value returns the last result call of this method, returning a wrong or unexpected result.

Fixing it, removing the memoize of this function.