### PR TITLE
Extend the Rails frameworks correctly

### DIFF
--- a/lib/name_of_person/loaders/active_model_has_person_name.rb
+++ b/lib/name_of_person/loaders/active_model_has_person_name.rb
@@ -1,3 +1,9 @@
-if defined?(ActiveModel)
-  ActiveModel::Model.send :include, NameOfPerson::HasPersonName
+if ActiveSupport.gem_version < "7.1.0.alpha"
+  ActiveSupport.on_load(:active_model) do
+    include NameOfPerson::HasPersonName
+  end
+else
+  if defined?(ActiveModel)
+    ActiveModel::Model.send :include, NameOfPerson::HasPersonName
+  end
 end

--- a/lib/name_of_person/loaders/active_record_has_person_name.rb
+++ b/lib/name_of_person/loaders/active_record_has_person_name.rb
@@ -1,3 +1,3 @@
-if defined?(ActiveRecord)
-  ActiveRecord::Base.send :include, NameOfPerson::HasPersonName
+ActiveSupport.on_load(:active_record) do
+  include NameOfPerson::HasPersonName
 end

--- a/lib/name_of_person/person_name.rb
+++ b/lib/name_of_person/person_name.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext/string'
 
 module NameOfPerson


### PR DESCRIPTION
As the code was before, this gem was forcing the Active Record and Active Model frameworks to be loaded too early in the Rails boot process.

Instead of Active Record and Active Model being loaded when the the application stats to initialize, they would be loaded when this gem is required, making the Rails configuration options for these frameworks to not be applied from the application.