### PR TITLE
fixed version check for 2.7.4

### DIFF
--- a/lib/name_of_person/loaders/active_model_has_person_name.rb
+++ b/lib/name_of_person/loaders/active_model_has_person_name.rb
@@ -1,4 +1,4 @@
-if ActiveSupport.gem_version < "7.1.0.alpha"
+if ActiveSupport.gem_version < Gem::Version.new('7.1.0.alpha')
   if defined?(ActiveModel)
     ActiveModel::Model.send :include, NameOfPerson::HasPersonName
   end


### PR DESCRIPTION
This fixes the error `active_model_has_person_name.rb:1:in `<': comparison of Gem::Version with String failed (ArgumentError)`